### PR TITLE
:sparkles: Add independently verifiable contentHash to Essay NFT

### DIFF
--- a/bid_essay_nft.sh
+++ b/bid_essay_nft.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+forge script script/BidEssay.s.sol:ListEssayScript --rpc-url=$RPC_URL --private-key=$PRIVATE_KEY --broadcast --slow --ffi

--- a/build.rs
+++ b/build.rs
@@ -8,13 +8,13 @@ fn main() {
         .write_to_file("target/SevenTeenTwentyNineEssay.rs").expect("Failed to write to file");
     // FIXME: Where should the output go?
 
-    println!("cargo:rerun-if-changed=out/ListBidEssay.s.sol/ModuleManager.json");
-    Abigen::new("ModuleManager", "out/ListBidEssay.s.sol/ModuleManager.json").expect("Failed to create new abigen")
+    println!("cargo:rerun-if-changed=out/ListEssay.s.sol/ModuleManager.json");
+    Abigen::new("ModuleManager", "out/ListEssay.s.sol/ModuleManager.json").expect("Failed to create new abigen")
         .generate().expect("Failed to generate")
         .write_to_file("target/ModuleManager.rs").expect("Failed to write to file");
 
-    println!("cargo:rerun-if-changed=out/ListBidEssay.s.sol/ReserveAuctionCoreETH.json");
-        Abigen::new("ModuleManager", "out/ListBidEssay.s.sol/ReserveAuctionCoreETH.json").expect("Failed to create new abigen")
+    println!("cargo:rerun-if-changed=out/ListEssay.s.sol/ReserveAuctionCoreETH.json");
+        Abigen::new("ModuleManager", "out/ListEssay.s.sol/ReserveAuctionCoreETH.json").expect("Failed to create new abigen")
         .generate().expect("Failed to generate")
         .write_to_file("target/ReserveAuctionCoreETH.rs").expect("Failed to write to file");
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,4 @@ src = 'src'
 test = 'tests/unit'
 out = 'out'
 libs = ['lib']
-solc_version = '0.8.17'
+solc_version = '0.8.13'

--- a/list_essay_nft.sh
+++ b/list_essay_nft.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-forge script script/ListBidEssay.s.sol:ListBidEssayScript --rpc-url=$RPC_URL --private-key=$PRIVATE_KEY --broadcast --slow --ffi
+forge script script/ListBidEssay.s.sol:ListEssayScript --rpc-url=$RPC_URL --private-key=$PRIVATE_KEY --broadcast --slow --ffi

--- a/script/BidEssay.s.sol
+++ b/script/BidEssay.s.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+
+import {SevenTeenTwentyNineEssay} from "../src/1729Essay.sol";
+import {Solenv} from "solenv/Solenv.sol";
+
+contract ListBidEssayScript is Script {
+    //
+    function run() public {
+        // Load config from .env
+        Solenv.config();
+        address TOKEN_ADDRESS = vm.envAddress("TOKEN_ADDRESS");
+        address MULTISIG_ADDRESS = vm.envAddress("MULTISIG_ADDRESS");
+        address AUCTION_HOUSE_ADDRESS = vm.envAddress("AUCTION_HOUSE_ADDRESS");
+        address MODULE_MANAGER_ADDRESS = vm.envAddress("MODULE_MANAGER_ADDRESS");
+        address TRANSFER_HELPER_ADDRESS = vm.envAddress("TRANSFER_HELPER_ADDRESS");
+        uint256 TOKEN_ID = vm.envUint("TOKEN_ID");
+        address AUTHOR_ADDRESS = vm.envAddress("AUTHOR_ADDRESS");
+        uint256 AUCTION_DURATION = vm.envUint("AUCTION_DURATION");
+        uint256 AUCTION_RESERVE_PRICE = vm.envUint("AUCTION_RESERVE_PRICE");
+        uint256 BID_AMOUNT = vm.envUint("BID_AMOUNT");
+
+        // set up auctionhouse
+        ReserveAuctionCoreETH auctionHouse = ReserveAuctionCoreETH(AUCTION_HOUSE_ADDRESS);
+
+        // get already deployed Essay NFT contract
+        SevenTeenTwentyNineEssay nft = SevenTeenTwentyNineEssay(TOKEN_ADDRESS);
+
+        // place bid on essay
+        vm.startBroadcast();
+        auctionHouse.createBid{value: BID_AMOUNT}(vm.envAddress("TOKEN_ADDRESS"), TOKEN_ID);
+        vm.stopBroadcast();
+    }
+}
+
+abstract contract ReserveAuctionCoreETH {
+    //
+    function createAuction(
+        address _tokenContract,
+        uint256 _tokenId,
+        uint256 _duration,
+        uint256 _reservePrice,
+        address _sellerFundsRecipient,
+        uint256 _startTime
+    )
+        public
+        virtual;
+
+    function setAuctionReservePrice(address _tokenContract, uint256 _tokenId, uint256 _reservePrice) public virtual;
+
+    function cancelAuction(address _tokenContract, uint256 _tokenId) public virtual;
+
+    function createBid(address _tokenContract, uint256 _tokenId) public payable virtual;
+
+    function settleAuction(address _tokenContract, uint256 _tokenId) public virtual;
+
+    /// @dev ERC-721 token contract => ERC-721 token id => Auction
+    mapping(address => mapping(uint256 => Auction)) public auctionForNFT;
+}
+
+abstract contract ModuleManager {
+    function setApprovalForModule(address _moduleAddress, bool _approved) public virtual;
+}
+
+struct Auction {
+    address seller;
+    uint96 reservePrice;
+    address sellerFundsRecipient;
+    uint96 highestBid;
+    address highestBidder;
+    uint32 duration;
+    uint32 startTime;
+    uint32 firstBidTime;
+}

--- a/script/ListEssay.s.sol
+++ b/script/ListEssay.s.sol
@@ -48,10 +48,6 @@ contract ListBidEssayScript is Script {
         require(duration == AUCTION_DURATION);
         vm.stopBroadcast();
 
-        // place bid on essay
-        vm.startBroadcast();
-        auctionHouse.createBid{value: BID_AMOUNT}(vm.envAddress("TOKEN_ADDRESS"), TOKEN_ID);
-        vm.stopBroadcast();
     }
 }
 

--- a/script/MintEssay.s.sol
+++ b/script/MintEssay.s.sol
@@ -14,7 +14,9 @@ contract MintEssayScript is Script {
         address tokenAddress = vm.envAddress("TOKEN_ADDRESS");
         address multisig = vm.envAddress("MULTISIG_ADDRESS");
         address authorAddress = vm.envAddress("AUTHOR_ADDRESS");
-        string memory essayUrl = vm.envString("ESSAY_URL");
+        bytes32 contentHash = vm.envBytes32("CONTENT_HASH");
+        string memory metadataUri = vm.envString("METADATA_URI");
+
         // generate hash for Essay markdown
 
         // upload Essay image to IPFS
@@ -30,7 +32,7 @@ contract MintEssayScript is Script {
 
         // mint Essay NFT
         vm.broadcast(multisig);
-        token.mint(authorAddress, essayUrl);
+        token.mint(authorAddress, contentHash, metadataUri);
 
         // verify thangs look good (in what ways?)
     }

--- a/src/1729Essay.sol
+++ b/src/1729Essay.sol
@@ -24,8 +24,9 @@ contract SevenTeenTwentyNineEssay is Ownable, ERC721 {
     using Counters for Counters.Counter;
 
     struct EssayItem {
-        address author;
-        string url;
+        address writer;
+        bytes32 contentHash;
+        string metadataUri;
     }
 
     mapping(uint256 => EssayItem) public essays;
@@ -45,11 +46,18 @@ contract SevenTeenTwentyNineEssay is Ownable, ERC721 {
                         Views
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Get the Essay NFT content hash
+    /// @param tokenId The Token ID for a specific Essay NFT
+    /// @return Sha256 hash of the Essay Markdown content
+    function contentHash(uint256 tokenId) public view returns (bytes32) {
+        return essays[tokenId].contentHash;
+    }
+
     /// @notice Get the Essay NFT metadata URI
-    /// @param id The Token ID for a specific Essay NFT
-    /// @return Fully-qualified URI of an Essay NFT, e.g., XYZ
-    function tokenURI(uint256 id) public view override returns (string memory) {
-        return essays[id].url;
+    /// @param tokenId The Token ID for a specific Essay NFT
+    /// @return Fully-qualified URI of the Essay JSON metadata
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        return essays[tokenId].metadataUri;
     }
 
     /// @notice Returns the total of all tokens ever minted (includes tokens which have been burned)
@@ -67,7 +75,7 @@ contract SevenTeenTwentyNineEssay is Ownable, ERC721 {
         view
         returns (address receiver, uint256 royaltyAmount)
     {
-        return (essays[tokenId].author, salePrice / 10);
+        return (essays[tokenId].writer, salePrice / 10);
     }
 
     /// @dev see ERC165
@@ -83,13 +91,14 @@ contract SevenTeenTwentyNineEssay is Ownable, ERC721 {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Mint a new token, using the next available token ID
-    /// @param author the address of the writer, who will receive royalty payments
-    /// @param url the URL containing the essay JSON metadata
+    /// @param _writer the address of the writer, who will receive royalty payments
+    /// @param _contentHash the sha256 hash of the essay Markdown content
+    /// @param _tokenUri the token URI of the essay JSON metadata
     /// @return the tokenId for the newly minted token
-    function mint(address author, string calldata url) public onlyOwner returns (uint256) {
+    function mint(address _writer, bytes32 _contentHash, string calldata _tokenUri) public onlyOwner returns (uint256) {
         uint256 tokenId = nextTokenId.current();
         nextTokenId.increment();
-        EssayItem memory essay = EssayItem(author, url);
+        EssayItem memory essay = EssayItem(_writer, _contentHash, _tokenUri);
         essays[tokenId] = essay;
         _safeMint(owner(), tokenId);
 

--- a/src/1729Essay.sol
+++ b/src/1729Essay.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import {ERC721} from "openzeppelin-contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";

--- a/src/1729ProofOfContribution.sol
+++ b/src/1729ProofOfContribution.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import {ProofOfContribution} from "./ProofOfContribution.sol";
 

--- a/src/1729WritersCohort2.sol
+++ b/src/1729WritersCohort2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.13;
 
 import "openzeppelin-contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/src/ISoulbound.sol
+++ b/src/ISoulbound.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 /// @title An ERC1155-flavored SBT / cryptocredential standard
 /// @author neodaoist

--- a/src/ProofOfContribution.sol
+++ b/src/ProofOfContribution.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import "./ISoulbound.sol";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,9 @@ use ethers_core::utils::hex;
 
 // Generate Rust bindings for all required contracts
 abigen!(SevenTeenTwentyNineEssay, "out/1729Essay.sol/SevenTeenTwentyNineEssay.json");
-abigen!(ListBidEssayScript, "out/ListBidEssay.s.sol/ListBidEssayScript.json");
-abigen!(ReserveAuctionCoreETH, "out/ListBidEssay.s.sol/ReserveAuctionCoreETH.json");
-abigen!(ModuleManager, "out/ListBidEssay.s.sol/ModuleManager.json");
+abigen!(ListBidEssayScript, "out/ListEssay.s.sol/ListBidEssayScript.json");
+abigen!(ReserveAuctionCoreETH, "out/ListEssay.s.sol/ReserveAuctionCoreETH.json");
+abigen!(ModuleManager, "out/ListEssay.s.sol/ModuleManager.json");
 
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use async_std::task;
 use ethers::abi::Uint;
 use std::env;
+use ethers_core::utils::hex;
 
 // Generate Rust bindings for all required contracts
 abigen!(SevenTeenTwentyNineEssay, "out/1729Essay.sol/SevenTeenTwentyNineEssay.json");
@@ -46,7 +47,9 @@ async fn main() {
     let nft_contract = task::block_on(SevenTeenTwentyNineEssay::deploy(client, multisig).expect("Failed to deploy").send()).expect("Failed to send");
 
     // Mint Essay NFT
-    let mint_call = nft_contract.mint(multisig, "https://test.com/test".to_string());
+    const SHA_SUM:[u8; 32] = [0xb1,0x67,0x41,0x91,0xa8,0x8e,0xc5,0xcd,0xd7,0x33,0xe4,0x24,0x0a,0x81,0x80,0x31,0x05,
+        0xdc,0x41,0x2d,0x6c,0x67,0x08,0xd5,0x3a,0xb9,0x4f,0xc2,0x48,0xf4,0xf5,0x53];
+    let mint_call = nft_contract.mint(multisig, SHA_SUM, "https://test.com/test".to_string());
     task::block_on(mint_call.send()).expect("Failed to send mint transaction");
 
     // Query Total Supply

--- a/tests/writers.rs
+++ b/tests/writers.rs
@@ -436,7 +436,9 @@ async fn publish_when_1(world: &mut WriterWorld) {
     let multisig = wallet.address();
 
     let nft_contract = world.nft_contract.as_ref().unwrap();
-    let mint_call = nft_contract.mint(multisig, "https://test.com/test".to_string());
+    const SHA_SUM:[u8; 32] = [0xb1,0x67,0x41,0x91,0xa8,0x8e,0xc5,0xcd,0xd7,0x33,0xe4,0x24,0x0a,0x81,0x80,0x31,0x05,
+        0xdc,0x41,0x2d,0x6c,0x67,0x08,0xd5,0x3a,0xb9,0x4f,0xc2,0x48,0xf4,0xf5,0x53];
+    let mint_call = nft_contract.mint(multisig, SHA_SUM, "https://test.com/test".to_string());  // TO-DO: Parameterize the URL and content hash
     task::block_on(mint_call.send()).expect("Failed to send mint transaction");
 
         // List

--- a/tests/writers.rs
+++ b/tests/writers.rs
@@ -23,9 +23,9 @@ use ethers::abi::Uint;
 
 
 abigen!(SevenTeenTwentyNineEssay, "out/1729Essay.sol/SevenTeenTwentyNineEssay.json");
-abigen!(ListBidEssayScript, "out/ListBidEssay.s.sol/ListBidEssayScript.json");
-abigen!(ReserveAuctionCoreETH, "out/ListBidEssay.s.sol/ReserveAuctionCoreETH.json");
-abigen!(ModuleManager, "out/ListBidEssay.s.sol/ModuleManager.json");
+abigen!(ListBidEssayScript, "out/ListEssay.s.sol/ListBidEssayScript.json");
+abigen!(ReserveAuctionCoreETH, "out/ListEssay.s.sol/ReserveAuctionCoreETH.json");
+abigen!(ModuleManager, "out/ListEssay.s.sol/ModuleManager.json");
 
 // `World` is your shared, likely mutable state.
 //#[derive(Debug, WorldInit)]


### PR DESCRIPTION
`essayUrl` becomes `contentHash` and `metadataUri` — the independently verifiability of the sha256 content hash is powerful. otherwise users/collectors won't be able to verify content hasn't changed unless they understand IPFS content addressing rules. 